### PR TITLE
fix time and date not updating

### DIFF
--- a/src/si4684.cpp
+++ b/src/si4684.cpp
@@ -381,7 +381,7 @@ void DAB::EnsembleInfo(void) {
     cts();
     SPIread(11);
 
-    if (SPIbuffer[0] == 0xe8) {
+    if (SPIbuffer[0] == 0xE9) {
       Year = SPIbuffer[5] + ((uint16_t)SPIbuffer[6] << 8);
       Months = SPIbuffer[7];
       Days = SPIbuffer[8];


### PR DESCRIPTION
This PR fixes the issue were both time and date were not updated on the display.

fixes https://github.com/PE5PVB/SI4684-DAB-Receiver/issues/17