### PR TITLE
fix compilation on case sensitive systems

### DIFF
--- a/src/TPA6130A2.cpp
+++ b/src/TPA6130A2.cpp
@@ -1,4 +1,4 @@
-#include "tpa6130a2.h"
+#include "TPA6130A2.h"
 
 byte TPA6130A2::Init(void) {
   Wire.begin();

--- a/src/gui.h
+++ b/src/gui.h
@@ -5,7 +5,7 @@
 #include <TFT_eSPI.h>
 #include <TimeLib.h>
 #include "si4684.h"
-#include "tpa6130a2.h"
+#include "TPA6130A2.h"
 #include "language.h"
 #include "constants.h"
 #include "graphics.h"


### PR DESCRIPTION
the software doensn't compile on case-sensitive systems (eg. linux) due to incorrect casing of some header inclusions.
this PR fixes that problem.