### PR TITLE
Ir remote support

### DIFF
--- a/SI4684-DAB-Receiver.ino
+++ b/SI4684-DAB-Receiver.ino
@@ -328,9 +328,11 @@ void setup(void) {
   BuildDisplay();
   setupmode = false;
   tottimer = millis();
+  IRReceiverBegin();
 }
 
 void loop(void) {
+  IRReceiver();
   ProcessDAB();
   Communication();
   displayreset = false;

--- a/platformio.ini
+++ b/platformio.ini
@@ -28,5 +28,7 @@ lib_deps =
 	paulstoffregen/Time
 	bodmer/TFT_eSPI
 	bitbank2/PNGdec
+	crankyoldgit/IRremoteESP8266
+
 
 extra_scripts = replace_fs.py

--- a/src/IRReceiver.cpp
+++ b/src/IRReceiver.cpp
@@ -1,0 +1,68 @@
+#include "IRReceiver.h"
+
+uint16_t RECV_PIN = 12;
+IRrecv irrecv(RECV_PIN);
+decode_results results;
+uint32_t lastCode = 0;
+
+void IRReceiverBegin() {
+  irrecv.enableIRIn();
+}
+
+void IRReceiver() {
+ if (irrecv.decode(&results)) {
+    uint32_t code = results.value;
+
+    Serial.println(code ,HEX);
+
+   if (code == 0xFFFFFFFF) {
+        if (lastCode == 0x77E1604F || lastCode == 0x77E1E04E || lastCode == 0xFF5AA5 || lastCode == 0x77E1904F || lastCode == 0x77E1104E || lastCode == 0xFF10EF) {
+            code = lastCode;
+        } else {
+            code = 0;  
+        }
+    } else {
+        lastCode = code;
+    }
+    switch (code) {
+      case 0x77E1504F:
+      case 0x77E1D04E:
+      case 0xFF18E7:   // Up_Key
+        KeyUp();
+        break;
+      case 0x77E1304F:
+      case 0x77E1B04E:
+      case 0xFF4AB5:   // Down_Key
+        KeyDown();
+        break;
+      case 0x77E1604F:
+      case 0x77E1E04E:
+      case 0xFF5AA5:   // RightKey
+        KeyUp2();
+        break;
+      case 0x77E1904F:
+      case 0x77E1104E:
+      case 0xFF10EF:   // Left_Key
+        KeyDown2();
+        break;
+      case 0x77E13A4F:
+      case 0x77E1BA4E:
+      case 0xFF38C7:   // OK_Key
+        SlideShowButtonPress();
+        break;
+      case 0x77E1C04F:
+      case 0x77E1404E:
+      case 0xFF6897:   // Menu_Key
+        ButtonPress();
+        break;
+      case 0x77E1FA4F:
+      case 0x77E17A4E:
+      case 0xFFB04F:   // Play/Pause_Key
+        Button2Press();
+        break;
+      default:
+        break;
+    }
+    irrecv.resume();  // Receive the next value
+  }
+}

--- a/src/IRReceiver.h
+++ b/src/IRReceiver.h
@@ -1,0 +1,20 @@
+#ifndef IRRECEIVER_H
+#define IRRECEIVER_H
+
+#include <IRremoteESP8266.h>
+#include <IRrecv.h>
+#include <IRutils.h>
+
+void IRReceiver();
+void IRReceiverBegin();
+
+void KeyUp();
+void KeyDown();
+void KeyUp2();
+void KeyDown2();
+void SlideShowButtonPress();
+void ButtonPress();
+void Button2Press();
+void doStandby();
+
+#endif


### PR DESCRIPTION
Add support for IR Receiver. An IR sensor connected to pin D12 is required. For now, it is not possible to learn a remote control. You can use this remote control from aliexpress https://www.aliexpress.com/item/1005007335053121.html?spm=a2g0o.order_list.order_list_main.5.68891802lXmuCd or edit IRReceiver.cpp

<img width="390" height="261" alt="image" src="https://github.com/user-attachments/assets/0ce696c7-e523-45b2-a65e-52de7400e756" />

<img width="231" height="430" alt="image" src="https://github.com/user-attachments/assets/49abddd8-e006-45a1-9fa5-c95d8b54e2e2" />
